### PR TITLE
Filter NSFW by default, skip bundles, etc.

### DIFF
--- a/backendGameFetch.py
+++ b/backendGameFetch.py
@@ -112,7 +112,7 @@ def currentDeals(apiKey, numGames):
         gen = (game for game in gameJSON.get('data').get('list') if gamesFetched < numGames)
         for game in gen:
             if "bundle" in game["urls"]["buy"]:
-                gameOffset += 10
+                gameOffset += 1
                 continue
             gameHTML = retrieveMeta(game["urls"]["buy"], "html", None)
             if retrieveMeta(game["urls"]["buy"], "rating", gameHTML) == "SFW":


### PR DESCRIPTION
Decided to filter out NSFW results by default, which leads to a more complicated logic to get deals. Deals will continue to be queried until the desired amount of SFW games (note: not bundles) is returned. Due to this new logic, loading times suffer somewhat, but I mitigated this by querying 10 games from the ITAD API at a time and then going off this list for logic before querying the next 10. Decided to skip bundles because of the significant load times incurred due to the recursive nature of searching each game for ratings.